### PR TITLE
Add support for extracting xattrs on unix

### DIFF
--- a/extractor/tgz_extractor.go
+++ b/extractor/tgz_extractor.go
@@ -105,5 +105,9 @@ func extractTarArchiveFile(header *tar.Header, dest string, input io.Reader) err
 	defer fileCopy.Close()
 
 	_, err = io.Copy(fileCopy, input)
-	return err
+	if err != nil {
+		return err
+	}
+
+	return setXattrsFromTar(filePath, header)
 }

--- a/extractor/xattr_unix.go
+++ b/extractor/xattr_unix.go
@@ -1,0 +1,29 @@
+//go:build unix
+
+package extractor
+
+import (
+	"archive/tar"
+	"errors"
+	"strings"
+	"syscall"
+
+	"golang.org/x/sys/unix"
+)
+
+func setXattrsFromTar(path string, hdr *tar.Header) (err error) {
+	const paxSchilyXattr = "SCHILY.xattr."
+
+	for key, value := range hdr.PAXRecords {
+		if !strings.HasPrefix(key, paxSchilyXattr) {
+			continue
+		}
+
+		err = unix.Lsetxattr(path, key[len(paxSchilyXattr):], []byte(value), 0)
+		if err != nil && !errors.Is(err, syscall.ENOTSUP) && !errors.Is(err, syscall.EPERM) {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/extractor/xattr_windows.go
+++ b/extractor/xattr_windows.go
@@ -1,0 +1,9 @@
+//go:build windows
+
+package extractor
+
+import "archive/tar"
+
+func setXattrsFromTar(_ string, _ *tar.Header) error {
+	return nil
+}


### PR DESCRIPTION
- [x] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
---------------
When extended file attributes are set on a file in the archive, try to preserve them on extraction but do not fail when the user does not have permission to set them or if they are not supported. This should prevent existing usages from breaking while also enabling users to preserve extended file attributes.

Part of https://github.com/cloudfoundry/diego-release/pull/1092

Backward Compatibility
---------------
Breaking Change? **No**
